### PR TITLE
🚧 wip: save edited resources as new items

### DIFF
--- a/components/data/DataDisplay.vue
+++ b/components/data/DataDisplay.vue
@@ -17,7 +17,7 @@ const hasContent = computed(() => props.content.length > 0);
   <div>
     <h3 class="pb-2 pt-5">{{ title }}</h3>
 
-    <p v-if="hasContent" class="text-lg">{{ content }}</p>
+    <p v-if="hasContent" class="text-base text-slate-800">{{ content }}</p>
 
     <slot v-else />
   </div>

--- a/components/modal/ModalNewCollection.vue
+++ b/components/modal/ModalNewCollection.vue
@@ -46,6 +46,7 @@ const createCollection = () => {
         body: JSON.stringify({
           title: formValue.name.trim(),
           description: formValue.description.trim(),
+          type: formValue.type,
         }),
         headers: useRequestHeaders(["cookie"]),
         method: "POST",

--- a/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/index.vue
+++ b/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/index.vue
@@ -70,7 +70,7 @@ if (error.value) {
           :content="collection?.detailedDescription || ''"
         />
 
-        <p v-else class="text-lg">No detailed description provided</p>
+        <p v-else class="text-base">No detailed description provided</p>
       </DataDisplay>
 
       <DataDisplay title="Identifier" :content="collection?.identifier" />

--- a/pages/dashboard/workspaces/[workspaceid]/index.vue
+++ b/pages/dashboard/workspaces/[workspaceid]/index.vue
@@ -71,11 +71,11 @@ if (error.value) {
             class="flex w-full items-center justify-between gap-x-3 border-b pb-3"
           >
             <div class="flex flex-col">
-              <p class="text-lg font-medium leading-tight">
+              <p class="font-inter text-lg font-medium leading-tight">
                 {{ collection.title }}
               </p>
 
-              <span class="mt-1 text-sm text-slate-500">
+              <span class="text-sm text-slate-500">
                 Updated on
                 {{ $dayjs(collection.updated).format("MMMM DD, YYYY") }}
               </span>


### PR DESCRIPTION
## Summary by Sourcery

Implement saving edited resources as new items with distinct versions and ensure new versions have back links.

New Features:
- Introduce a mechanism to save edited resources as new items with their own version.

Enhancements:
- Ensure that a new version of a resource always has a back link.