### PR TITLE
✨ feat: add support for a canonical id

### DIFF
--- a/pages/dashboard/index.vue
+++ b/pages/dashboard/index.vue
@@ -72,10 +72,11 @@ workspaceStore.setWorkspaces(workspaces.value || []);
             <UAvatar
               size="xl"
               :src="`https://api.dicebear.com/7.x/shapes/svg?seed=${workspace.id}`"
+              class="mt-1"
             />
 
-            <div class="flex flex-col">
-              <div class="flex items-center justify-between gap-2">
+            <div class="flex w-full flex-col">
+              <div class="flex w-full items-start justify-between gap-2">
                 <span class="text-lg font-medium">
                   {{ workspace.title }}
                 </span>
@@ -84,6 +85,7 @@ workspaceStore.setWorkspaces(workspaces.value || []);
                   v-if="workspace.personal"
                   color="warning"
                   variant="outline"
+                  class="mt-1"
                 >
                   Personal
                 </UBadge>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,8 @@ model Version {
 model Resource {
     id String @id @default(cuid())
 
+    canonicalId String // the canonical id for the resource (tracking across versions)
+
     identifierType String // doi, url, ror, orcid, etc (prefix from identifiers.org)
     identifier     String // the actual identifier (10.1234/abc)
 

--- a/scripts/truncate-tables.ts
+++ b/scripts/truncate-tables.ts
@@ -14,8 +14,8 @@ const truncateTables = async () => {
   console.log("Truncating table WorkspaceMember...");
   await prisma.$executeRaw`TRUNCATE TABLE "WorkspaceMember" RESTART IDENTITY CASCADE`;
 
-  console.log("Truncating table Workspace...");
-  await prisma.$executeRaw`TRUNCATE TABLE "Workspace" RESTART IDENTITY CASCADE`;
+  // console.log("Truncating table Workspace...");
+  // await prisma.$executeRaw`TRUNCATE TABLE "Workspace" RESTART IDENTITY CASCADE`;
 
   console.log("Truncating table Collection...");
   await prisma.$executeRaw`TRUNCATE TABLE "Collection" RESTART IDENTITY CASCADE`;
@@ -37,6 +37,9 @@ const truncateTables = async () => {
 
   console.log("Truncating table Notification...");
   await prisma.$executeRaw`TRUNCATE TABLE "Notification" RESTART IDENTITY CASCADE`;
+
+  // console.log("Truncating table User...");
+  // await prisma.$executeRaw`TRUNCATE TABLE "User" RESTART IDENTITY CASCADE`;
 };
 
 const main = async () => {

--- a/server/api/workspaces/[workspaceid]/collections/[collectionid]/resources/index.post.ts
+++ b/server/api/workspaces/[workspaceid]/collections/[collectionid]/resources/index.post.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { nanoid } from "nanoid";
 import collectionMinEditorPermission from "~/server/utils/collection/collectionMinEditorPermission";
 import touchCollection from "~/server/utils/collection/touchCollection";
 
@@ -85,6 +86,7 @@ export default defineEventHandler(async (event) => {
       title,
       action: "create",
       backLinkId: null,
+      canonicalId: nanoid(),
       description,
       identifier,
       identifierType,

--- a/server/utils/collection/collectionNewVersion.ts
+++ b/server/utils/collection/collectionNewVersion.ts
@@ -70,6 +70,7 @@ export default async function (collectionId: number) {
           title: resource.title,
           action: "clone",
           backLinkId: null,
+          canonicalId: resource.canonicalId,
           description: resource.description,
           identifier: resource.identifier,
           identifierType: resource.identifierType,

--- a/types/kysely.ts
+++ b/types/kysely.ts
@@ -77,6 +77,7 @@ export type Notification = {
 };
 export type Resource = {
     id: string;
+    canonicalId: string;
     identifierType: string;
     identifier: string;
     title: Generated<string>;


### PR DESCRIPTION
## Summary by Sourcery

Adds a `canonicalId` field to the `Resource` type to provide a unique identifier for resources across different versions and clones. Also includes minor UI enhancements to the dashboard.

New Features:
- Introduces a `canonicalId` field to the `Resource` type, which is automatically generated when a new resource is created.
- The `canonicalId` is preserved when creating new versions of a collection.

Enhancements:
- Improves the dashboard UI by adding some spacing to the workspace cards.

Chores:
- Comments out the truncation of the `Workspace` and `User` tables in the `truncate-tables.ts` script.