### PR TITLE
fix: make version label mandatory for new resource versions

### DIFF
--- a/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/publish.vue
+++ b/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/publish.vue
@@ -256,7 +256,9 @@ const publishCollection = async () => {
 
                   <ul>
                     <li
-                      v-for="(issue, index) of error.issues"
+                      v-for="(issue, index) of 'issues' in error
+                        ? error.issues
+                        : []"
                       :key="index"
                       class="py-1 pl-2 text-base"
                     >

--- a/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/resources/[resourceid]/index.vue
+++ b/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/resources/[resourceid]/index.vue
@@ -191,6 +191,10 @@ const validateForm = (_state: any): FormError[] => {
     });
   }
 
+  if (!state.versionLabel) {
+    errors.push({ name: "version", message: "Version is required" });
+  }
+
   if (state.identifierType && state.identifier) {
     // run the identifier regex against the identifier
     const identifierRegex = new RegExp(
@@ -213,7 +217,7 @@ async function onSubmit(event: FormSubmitEvent<any>) {
     cloneRelations: event.data.cloneRelations || false,
     identifier: event.data.identifier || "",
     identifierType: event.data.identifierType || "",
-    versionLabel: event.data.versionLabel || "",
+    versionLabel: event.data.versionLabel,
   };
 
   newResourceVersionLoadingIndicator.value = true;

--- a/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/resources/index.vue
+++ b/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/resources/index.vue
@@ -208,37 +208,50 @@ const selectIcon = (type: string) => {
         <div
           class="flex w-full items-center gap-2 border-t border-slate-400 pt-3 pb-4"
         >
-          <UBadge
-            :color="resource.identifierType ? 'info' : 'error'"
-            size="sm"
-            variant="outline"
-          >
-            {{ resource.identifierType || "No identifier provided" }}
-          </UBadge>
+          <div class="flex w-full items-center justify-between gap-2">
+            <div class="flex w-full items-center gap-2">
+              <UBadge
+                :color="resource.identifierType ? 'info' : 'error'"
+                size="sm"
+                variant="outline"
+              >
+                {{ resource.identifierType || "No identifier provided" }}
+              </UBadge>
 
-          <USeparator orientation="vertical" class="h-5" />
+              <USeparator orientation="vertical" class="h-5" />
 
-          <div class="group w-max">
-            <ULink
-              :to="
-                resource.identifierType !== 'url'
-                  ? `https://identifiers.org/${resource.identifierType}/${resource.identifier}`
-                  : resource.identifier
-              "
-              class="flex items-center font-medium text-blue-600 transition-all group-hover:text-blue-700 group-hover:underline"
-              target="_blank"
-              @click.stop=""
-            >
-              {{ resource.identifier }}
+              <div class="group w-max">
+                <ULink
+                  :to="
+                    resource.identifierType !== 'url'
+                      ? `https://identifiers.org/${resource.identifierType}/${resource.identifier}`
+                      : resource.identifier
+                  "
+                  class="flex items-center font-medium text-blue-600 transition-all group-hover:text-blue-700 group-hover:underline"
+                  target="_blank"
+                  @click.stop=""
+                >
+                  {{ resource.identifier }}
 
-              <Icon
-                v-if="resource.identifierType"
-                name="mdi:external-link"
-                size="16"
-                class="ml-1 text-blue-600 transition-all group-hover:text-blue-700 group-hover:underline"
-              />
-            </ULink>
+                  <Icon
+                    v-if="resource.identifierType"
+                    name="mdi:external-link"
+                    size="16"
+                    class="ml-1 text-blue-600 transition-all group-hover:text-blue-700 group-hover:underline"
+                  />
+                </ULink>
+              </div>
+            </div>
           </div>
+
+          <UBadge
+            v-if="resource.versionLabel"
+            color="info"
+            size="sm"
+            variant="soft"
+          >
+            {{ resource.versionLabel }}
+          </UBadge>
         </div>
       </NuxtLink>
     </div>

--- a/server/api/workspaces/[workspaceid]/collections/[collectionid]/resource/[resourceid]/new-version.post.ts
+++ b/server/api/workspaces/[workspaceid]/collections/[collectionid]/resource/[resourceid]/new-version.post.ts
@@ -11,7 +11,7 @@ export default defineEventHandler(async (event) => {
       cloneRelations: z.boolean(),
       identifier: z.string().min(1),
       identifierType: z.string().min(1),
-      versionLabel: z.string().optional(),
+      versionLabel: z.string().min(1),
     })
     .strict();
 


### PR DESCRIPTION
## Summary by Sourcery

Require version labels for new resource versions by enforcing validation on both client and server, enhance the resource list UI to prominently display identifiers and version badges, and fix a rendering issue in the publish view.

Bug Fixes:
- Add client-side form validation to require version label when creating a new resource version
- Enforce non-empty versionLabel in the server-side schema for new resource versions
- Remove default fallback for versionLabel in submission payload to prevent empty values
- Fix v-for loop in publish view to safely iterate over error issues

Enhancements:
- Refactor resource list component to display identifier and version label badges in a consolidated layout