### PR TITLE
refactor: remove nuxt-headlessui dependency and update avatar image URLs

### DIFF
--- a/app/components/app/AppProfileDropdown.vue
+++ b/app/components/app/AppProfileDropdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-const { clear } = useUserSession();
+const { clear, user } = useUserSession();
+const route = useRoute();
 
 const logout = async () => {
   clear();
@@ -9,27 +10,48 @@ const logout = async () => {
 const items = ref([
   [
     {
-      icon: "uil:dashboard",
-      label: "Dashboard",
+      label: `${user?.value?.givenName} ${user?.value?.familyName}`,
+      avatar: {
+        src: `https://api.dicebear.com/9.x/shapes/svg?seed=${user?.value?.id}`,
+      },
+      type: "label",
     },
     {
-      icon: "bx:bxs-book-open",
-      label: "Catalog",
-    },
-    {
-      icon: "ic:baseline-settings",
-      label: "Settings",
-    },
-    {
-      icon: "heroicons-solid:star",
-      label: "Starred",
+      icon: "material-symbols:account-circle",
+      label: "Account settings",
+      to: "/account/settings",
     },
   ],
   [
     {
-      icon: "solar:home-bold",
-      label: "Home",
+      icon: "material-symbols:dashboard",
+      label: "Dashboard",
+      to: "/dashboard",
     },
+    {
+      icon: "material-symbols:home",
+      label: "Home page",
+      to: "/",
+    },
+  ],
+  [
+    {
+      icon: "material-symbols:add-circle",
+      label: "Create a new workspace",
+    },
+    {
+      icon: "material-symbols:star",
+      label: "Starred collections",
+      to: "/collections/starred",
+    },
+    {
+      icon: "material-symbols:visibility-off",
+      label: "Hidden collections",
+      to: `/dashboard/workspaces/${route.params.workspaceid}/settings/hidden-collections`,
+      disabled: !route.params.workspaceid,
+    },
+  ],
+  [
     {
       icon: "majesticons:logout",
       label: "Logout",
@@ -41,7 +63,7 @@ const items = ref([
 
 <template>
   <AuthState>
-    <template #default="{ loggedIn, user }">
+    <template #default="{ loggedIn }">
       <NuxtLink v-if="!loggedIn" to="/login">
         <UButton size="lg" label="Log in" />
       </NuxtLink>
@@ -52,6 +74,10 @@ const items = ref([
 
       <UDropdownMenu
         :items="items"
+        arrow
+        :content="{
+          align: 'end',
+        }"
         :ui="{
           content: 'w-48',
         }"

--- a/app/components/app/AppProfileDropdown.vue
+++ b/app/components/app/AppProfileDropdown.vue
@@ -59,7 +59,7 @@ const items = ref([
         <UButton
           v-if="loggedIn"
           :avatar="{
-            src: `https://api.dicebear.com/6.x/shapes/svg?seed=${user?.id}`,
+            src: `https://api.dicebear.com/9.x/shapes/svg?seed=${user?.id}`,
           }"
           size="xl"
           color="neutral"

--- a/app/components/header/HeaderLeftBar.vue
+++ b/app/components/header/HeaderLeftBar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DropdownMenuItem } from "@nuxt/ui";
 import { useWorkspaceStore } from "@/stores/workspace";
 
 const toast = useToast();
@@ -215,475 +216,268 @@ const navigateToResource = (resourceid: string) => {
     `/dashboard/workspaces/${selectedWorkspace.value}/collections/${selectedCollection.value}/resources/${resourceid}`,
   );
 };
+
+const workspaceItems = ref<DropdownMenuItem[][]>([
+  [
+    {
+      label: "My Personal Workspace",
+      id: personalWorkspace.value?.id || "",
+      avatar: {
+        src: `https://api.dicebear.com/9.x/identicon/svg?seed=${personalWorkspace.value?.id}`,
+      },
+      // to: `/dashboard/workspaces/${personalWorkspace.value?.id || ""}`,
+      onSelect: () => {
+        navigateToWorkspace(personalWorkspace.value?.id || "");
+      },
+    },
+  ],
+  ...(allOtherWorkspaces.value.length
+    ? [
+        allOtherWorkspaces.value.map((workspace: Workspace) => ({
+          id: workspace.id,
+          label: workspace.title,
+          avatar: {
+            src: `https://api.dicebear.com/9.x/identicon/svg?seed=${workspace.id}`,
+          },
+          // to: `/dashboard/workspaces/${workspace.id}`,
+          onSelect: () => {
+            navigateToWorkspace(workspace.id);
+          },
+        })),
+      ]
+    : []),
+  [
+    {
+      label: "Create a new workspace",
+      // to: "/dashboard/workspaces/new",
+      onSelect: createNewWorkspace,
+      icon: "ph:plus-circle-bold",
+    },
+  ],
+]);
+
+const collectionItems = computed<DropdownMenuItem[][]>(() => [
+  ...(allCollections.value.length
+    ? [
+        allCollections.value.map((collection: Collection) => ({
+          label: collection.title,
+          avatar: {
+            src: `https://api.dicebear.com/9.x/shapes/svg?seed=${collection.id}`,
+          },
+          onSelect: () => {
+            navigateToCollection(collection.id);
+          },
+        })),
+      ]
+    : []),
+  [
+    {
+      label: "Create a new collection",
+      onSelect: createNewCollection,
+      icon: "ph:plus-circle-bold",
+    },
+  ],
+]);
+
+const resourceItems = computed<DropdownMenuItem[][]>(() => [
+  ...(allResources.value.length
+    ? [
+        allResources.value.map((resource: ResourceType) => ({
+          label: resource.title,
+          onSelect: () => {
+            navigateToResource(resource.id);
+          },
+        })),
+      ]
+    : []),
+]);
 </script>
 
 <template>
   <div class="flex items-center justify-start">
-    <div class="w-max">
-      <HeadlessListbox v-model="selectedWorkspace">
-        <div class="relative">
-          <ContainerFlex align="center">
-            <NuxtLink :to="`/dashboard/workspaces/${currentWorkspace?.id}`">
-              <TransitionFade>
-                <div
-                  v-if="workspaceStore.getLoading"
-                  class="flex items-center justify-start gap-2"
-                >
-                  <USkeleton class="h-[20px] w-[20px] rounded-full" />
-
-                  <USkeleton
-                    v-if="workspaceStore.getLoading"
-                    class="h-[25px] w-[100px]"
-                  />
-                </div>
-
-                <div
-                  v-else
-                  class="flex items-center justify-start gap-2 rounded-md p-1 transition-all hover:bg-gray-50"
-                >
-                  <UAvatar
-                    :src="`https://api.dicebear.com/6.x/shapes/svg?seed=${currentWorkspace?.id}`"
-                    size="sm"
-                  />
-
-                  <span
-                    class="max-w-40 truncate text-base font-medium transition-all hover:text-gray-600"
-                  >
-                    {{ currentWorkspace?.title }}
-                  </span>
-
-                  <UBadge
-                    v-if="currentWorkspace?.personal"
-                    color="info"
-                    size="sm"
-                    class="pointer-events-none"
-                    variant="outline"
-                  >
-                    Personal
-                  </UBadge>
-                </div>
-              </TransitionFade>
-            </NuxtLink>
-
-            <HeadlessListboxButton
-              class="relative w-full cursor-pointer rounded-lg border border-slate-100 bg-white p-1 text-left transition-all hover:border-slate-300 hover:bg-slate-50 hover:shadow-sm sm:text-sm"
-            >
-              <span
-                class="pointer-events-none inset-y-0 right-0 flex items-center"
-              >
-                <Icon name="ph:caret-up-down-bold" class="h-5 w-5" />
-              </span>
-            </HeadlessListboxButton>
-          </ContainerFlex>
-
-          <transition
-            leave-active-class="transition duration-100 ease-in"
-            enter-active-class="transition duration-75 ease-out"
-            leave-from-class="opacity-100"
-            leave-to-class="opacity-0"
-            enter-from-class="opacity-0 transition transform origin-top-right scale-95"
-            enter-to-class="opacity-100 transform origin-top-right scale-100"
-          >
-            <HeadlessListboxOptions
-              class="absolute mt-1 max-h-60 w-max overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-slate-300 sm:text-sm"
-            >
-              <HeadlessListboxOption
-                v-slot="{ active, selected }"
-                :value="personalWorkspace?.id"
-                as="template"
-                @click="navigateToWorkspace(personalWorkspace?.id || '')"
-              >
-                <li
-                  :class="[
-                    active ? 'bg-amber-100 text-amber-900' : 'text-gray-900',
-                    'flex w-full cursor-pointer items-center justify-between px-4 py-2',
-                  ]"
-                >
-                  <div class="flex items-center justify-start gap-2 pr-4">
-                    <UAvatar
-                      :src="`https://api.dicebear.com/6.x/shapes/svg?seed=${personalWorkspace?.id}`"
-                      size="sm"
-                    />
-
-                    <span
-                      :class="[
-                        selected ? 'font-medium' : 'font-normal',
-                        'block truncate',
-                      ]"
-                    >
-                      {{ personalWorkspace?.title }}
-                    </span>
-                  </div>
-
-                  <span
-                    v-if="selected"
-                    class="flex items-center text-amber-600"
-                  >
-                    <Icon name="ph:check-bold" class="h-5 w-5" />
-                  </span>
-                </li>
-              </HeadlessListboxOption>
-
-              <div
-                v-if="allOtherWorkspaces.length > 0"
-                class="mx-auto my-1 h-[1px] w-[90%] bg-slate-200"
-              ></div>
-
-              <HeadlessListboxOption
-                v-for="(workspace, index) in allOtherWorkspaces"
-                v-slot="{ active, selected }"
-                :key="index"
-                :value="workspace.id"
-                as="template"
-                @click="navigateToWorkspace(workspace.id)"
-              >
-                <li
-                  :class="[
-                    active ? 'bg-amber-100 text-amber-900' : 'text-gray-900',
-                    'flex w-full cursor-pointer items-center justify-between px-4 py-2',
-                  ]"
-                >
-                  <div class="flex items-center justify-start gap-2 pr-4">
-                    <UAvatar
-                      :src="`https://api.dicebear.com/6.x/shapes/svg?seed=${workspace.id}`"
-                      size="sm"
-                    />
-
-                    <span
-                      :class="[
-                        selected ? 'font-medium' : 'font-normal',
-                        'block truncate',
-                      ]"
-                      >{{ workspace.title }}</span
-                    >
-                  </div>
-
-                  <span
-                    v-if="selected"
-                    class="flex items-center text-amber-600"
-                  >
-                    <Icon name="ph:check-bold" class="h-5 w-5" />
-                  </span>
-                </li>
-              </HeadlessListboxOption>
-
-              <div class="mx-auto my-1 h-[1px] w-[90%] bg-slate-200"></div>
-
-              <div @click="createNewWorkspace">
-                <li
-                  class="flex w-full cursor-pointer items-center justify-between px-4 py-2 text-gray-900"
-                >
-                  <div class="flex items-center justify-start gap-2 pr-4">
-                    <Icon name="ph:plus-circle-bold" />
-
-                    <span class="block truncate font-medium">
-                      Create a new workspace
-                    </span>
-                  </div>
-                </li>
-              </div>
-            </HeadlessListboxOptions>
-          </transition>
-        </div>
-      </HeadlessListbox>
+    <!-- Logo -->
+    <div>
+      <NuxtLink to="/dashboard">
+        <AppLogoIcon class="h-5 w-5" />
+      </NuxtLink>
     </div>
 
+    <!-- First / -->
     <TransitionFade>
-      <svg
-        v-if="route.params.collectionid"
-        fill="none"
-        shape-rendering="geometricPrecision"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="1"
-        viewBox="0 0 24 24"
-        width="14"
-        height="14"
-        class="h-8 w-8 text-gray-200"
-      >
-        <path d="M16.88 3.549L7.12 20.451"></path>
-      </svg>
+      <UIcon
+        v-if="route.params.workspaceid"
+        name="heroicons:slash-16-solid"
+        class="h-6 w-6 text-gray-200"
+      />
     </TransitionFade>
 
-    <TransitionFade>
-      <div v-if="route.params.collectionid" class="w-max">
-        <HeadlessListbox v-model="selectedCollection">
-          <div class="relative">
-            <ContainerFlex align="center">
-              <NuxtLink
-                :to="`/dashboard/workspaces/${currentWorkspace?.id}/collections/${selectedCollection}`"
+    <!-- Workspaces -->
+    <div class="flex items-center justify-start gap-2">
+      <ContainerFlex align="center">
+        <NuxtLink :to="`/dashboard/workspaces/${currentWorkspace?.id}`">
+          <TransitionFade>
+            <div
+              v-if="workspaceStore.getLoading"
+              class="flex items-center justify-start gap-2"
+            >
+              <USkeleton
+                v-if="workspaceStore.getLoading"
+                class="h-[25px] w-[100px]"
+              />
+            </div>
+
+            <div
+              v-else
+              class="flex items-center justify-start gap-2 rounded-md p-1 transition-all hover:bg-gray-50"
+            >
+              <span
+                class="max-w-40 truncate text-sm font-medium transition-all hover:text-gray-600"
               >
-                <TransitionFade>
-                  <div
-                    v-if="collectionStore.getLoading"
-                    class="flex items-center justify-start gap-2"
-                  >
-                    <USkeleton class="h-[20px] w-[20px] rounded-full" />
+                {{ currentWorkspace?.title }}
+              </span>
+            </div>
+          </TransitionFade>
+        </NuxtLink>
 
-                    <USkeleton class="h-[25px] w-[100px]" />
-                  </div>
+        <UDropdownMenu
+          :items="workspaceItems"
+          :ui="{
+            content: 'w-max',
+          }"
+        >
+          <UButton icon="mingcute:down-fill" color="neutral" variant="ghost" />
 
-                  <div
-                    v-else
-                    class="flex items-center justify-start gap-2 rounded-md p-1 transition-all hover:bg-gray-50"
-                  >
-                    <UAvatar
-                      :src="`${currentCollection?.imageUrl}?t=${currentCollection?.updated}`"
-                      size="sm"
-                    />
+          <template #item-trailing="{ item }">
+            <UIcon
+              v-if="item.id === currentWorkspace?.id"
+              name="streamline:check-solid"
+              class="mt-1 ml-1 size-3"
+            />
+          </template>
+        </UDropdownMenu>
+      </ContainerFlex>
+    </div>
 
-                    <span
-                      class="max-w-40 truncate text-base font-medium transition-all hover:text-gray-600"
-                    >
-                      {{ currentCollection?.title }}
-                    </span>
-                  </div>
-                </TransitionFade>
-              </NuxtLink>
+    <!-- Second / -->
+    <TransitionFade>
+      <UIcon
+        v-if="route.params.collectionid"
+        name="heroicons:slash-16-solid"
+        class="h-6 w-6 text-gray-200"
+      />
+    </TransitionFade>
 
-              <HeadlessListboxButton
-                class="relative w-full cursor-pointer rounded-lg border border-slate-100 bg-white p-1 text-left transition-all hover:border-slate-300 hover:bg-slate-50 hover:shadow-sm sm:text-sm"
+    <!-- Collections -->
+    <TransitionFade>
+      <div
+        v-if="route.params.collectionid"
+        class="flex items-center justify-start gap-2"
+      >
+        <ContainerFlex align="center">
+          <NuxtLink
+            :to="`/dashboard/workspaces/${currentWorkspace?.id}/collections/${selectedCollection}`"
+          >
+            <TransitionFade>
+              <div
+                v-if="collectionStore.getLoading"
+                class="flex items-center justify-start gap-2"
+              >
+                <USkeleton class="h-[25px] w-[100px]" />
+              </div>
+
+              <div
+                v-else
+                class="flex items-center justify-start gap-2 rounded-md p-1 transition-all hover:bg-gray-50"
               >
                 <span
-                  class="pointer-events-none inset-y-0 right-0 flex items-center"
+                  class="max-w-40 truncate text-sm font-medium transition-all hover:text-gray-600"
                 >
-                  <Icon name="ph:caret-up-down-bold" class="h-5 w-5" />
+                  {{ currentCollection?.title }}
                 </span>
-              </HeadlessListboxButton>
-            </ContainerFlex>
+              </div>
+            </TransitionFade>
+          </NuxtLink>
 
-            <transition
-              leave-active-class="transition duration-100 ease-in"
-              enter-active-class="transition duration-75 ease-out"
-              leave-from-class="opacity-100"
-              leave-to-class="opacity-0"
-              enter-from-class="opacity-0 transition transform origin-top-right scale-95"
-              enter-to-class="opacity-100 transform origin-top-right scale-100"
-            >
-              <HeadlessListboxOptions
-                class="absolute mt-1 max-h-60 w-max overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 sm:text-sm"
-              >
-                <HeadlessListboxOption
-                  v-for="collection in allCollections"
-                  v-slot="{ active, selected }"
-                  :key="collection.id"
-                  :value="collection.id"
-                  as="template"
-                  @click="navigateToCollection(collection.id)"
-                >
-                  <li
-                    :class="[
-                      active ? 'bg-amber-100 text-amber-900' : 'text-gray-900',
-                      'flex w-full cursor-pointer items-center justify-between px-4 py-1',
-                    ]"
-                  >
-                    <div class="flex items-center justify-start gap-2 pr-4">
-                      <UAvatar
-                        :src="`${collection?.imageUrl}?t=${collection?.updated}`"
-                        size="sm"
-                      />
-
-                      <UTooltip
-                        v-if="collection.title.length > 19"
-                        :text="collection.title"
-                      >
-                        <span
-                          :class="[
-                            selected ? 'font-medium' : 'font-normal',
-                            'block max-w-40 truncate',
-                          ]"
-                        >
-                          {{ collection.title }}
-                        </span>
-                      </UTooltip>
-
-                      <span
-                        v-else
-                        :class="[
-                          selected ? 'font-medium' : 'font-normal',
-                          'block max-w-40 truncate',
-                        ]"
-                      >
-                        {{ collection.title }}
-                      </span>
-                    </div>
-
-                    <span
-                      v-if="selected"
-                      class="flex items-center text-amber-600"
-                    >
-                      <Icon name="ph:check-bold" class="h-5 w-5" />
-                    </span>
-                  </li>
-                </HeadlessListboxOption>
-
-                <div class="mx-auto my-1 h-[1px] w-[90%] bg-slate-200"></div>
-
-                <div @click="createNewCollection">
-                  <li
-                    class="flex w-full cursor-pointer items-center justify-between px-4 py-2 text-gray-900"
-                  >
-                    <div class="flex items-center justify-start gap-2 pr-4">
-                      <Icon name="ph:plus-circle-bold" />
-
-                      <span class="block truncate font-medium">
-                        Create a new collection
-                      </span>
-                    </div>
-                  </li>
-                </div>
-              </HeadlessListboxOptions>
-            </transition>
-          </div>
-        </HeadlessListbox>
+          <UDropdownMenu
+            :items="collectionItems"
+            :ui="{
+              content: 'w-max',
+            }"
+          >
+            <UButton
+              icon="mingcute:down-fill"
+              color="neutral"
+              variant="ghost"
+            />
+          </UDropdownMenu>
+        </ContainerFlex>
       </div>
     </TransitionFade>
 
+    <!-- Third / -->
     <TransitionFade>
-      <svg
+      <UIcon
         v-if="route.params.resourceid"
-        fill="none"
-        shape-rendering="geometricPrecision"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="1"
-        viewBox="0 0 24 24"
-        width="14"
-        height="14"
-        class="h-8 w-8 text-gray-200"
-      >
-        <path d="M16.88 3.549L7.12 20.451"></path>
-      </svg>
+        name="heroicons:slash-16-solid"
+        class="h-6 w-6 text-gray-200"
+      />
     </TransitionFade>
 
+    <!-- Resources -->
     <TransitionFade>
-      <div v-if="route.params.resourceid" class="w-max">
-        <HeadlessListbox v-model="selectedResource">
-          <div class="relative">
-            <ContainerFlex align="center">
-              <NuxtLink
-                :to="`/dashboard/workspaces/${currentWorkspace?.id}/collections/${selectedCollection}/resources/${selectedResource}`"
+      <div
+        v-if="route.params.resourceid"
+        class="flex items-center justify-start gap-2"
+      >
+        <ContainerFlex align="center">
+          <NuxtLink
+            :to="`/dashboard/workspaces/${currentWorkspace?.id}/collections/${selectedCollection}/resources/${selectedResource}`"
+          >
+            <TransitionFade>
+              <div
+                v-if="resourceStore.getLoading"
+                class="flex items-center justify-start gap-2"
               >
-                <TransitionFade>
-                  <div
-                    v-if="resourceStore.getLoading"
-                    class="flex items-center justify-start gap-2"
-                  >
-                    <USkeleton class="h-[20px] w-[20px] rounded-full" />
+                <USkeleton class="h-[25px] w-[100px]" />
+              </div>
 
-                    <USkeleton class="h-[25px] w-[100px]" />
-                  </div>
-
-                  <div
-                    v-else
-                    class="flex items-center justify-start gap-2 rounded-md p-1 transition-all hover:bg-gray-50"
-                  >
-                    <UAvatar
-                      :src="`https://api.dicebear.com/6.x/shapes/svg?seed=${selectedResource}`"
-                      size="sm"
-                    />
-
-                    <span
-                      v-if="currentResource?.title"
-                      class="max-w-40 truncate text-base font-medium transition-all hover:text-gray-600"
-                    >
-                      {{ currentResource?.title }}
-                    </span>
-
-                    <UBadge
-                      v-else
-                      color="success"
-                      size="sm"
-                      class="pointer-events-none"
-                      variant="outline"
-                    >
-                      New
-                    </UBadge>
-                  </div>
-                </TransitionFade>
-              </NuxtLink>
-
-              <HeadlessListboxButton
-                class="relative w-full cursor-pointer rounded-lg border border-slate-100 bg-white p-1 text-left transition-all hover:border-slate-300 hover:bg-slate-50 hover:shadow-sm sm:text-sm"
+              <div
+                v-else
+                class="flex items-center justify-start gap-2 rounded-md p-1 transition-all hover:bg-gray-50"
               >
                 <span
-                  class="pointer-events-none inset-y-0 right-0 flex items-center"
+                  v-if="currentResource?.title"
+                  class="max-w-40 truncate text-sm font-medium transition-all hover:text-gray-600"
                 >
-                  <Icon name="ph:caret-up-down-bold" class="h-5 w-5" />
+                  {{ currentResource?.title }}
                 </span>
-              </HeadlessListboxButton>
-            </ContainerFlex>
 
-            <transition
-              leave-active-class="transition duration-100 ease-in"
-              enter-active-class="transition duration-75 ease-out"
-              leave-from-class="opacity-100"
-              leave-to-class="opacity-0"
-              enter-from-class="opacity-0 transition transform origin-top-right scale-95"
-              enter-to-class="opacity-100 transform origin-top-right scale-100"
-            >
-              <HeadlessListboxOptions
-                class="absolute mt-1 max-h-60 w-max overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 sm:text-sm"
-              >
-                <HeadlessListboxOption
-                  v-for="resource in allResources"
-                  v-slot="{ active, selected }"
-                  :key="resource.id"
-                  :value="resource.id"
-                  as="template"
-                  @click="navigateToResource(resource.id)"
+                <UBadge
+                  v-else
+                  color="success"
+                  size="sm"
+                  class="pointer-events-none"
+                  variant="outline"
                 >
-                  <li
-                    :class="[
-                      active ? 'bg-amber-100 text-amber-900' : 'text-gray-900',
-                      'flex w-full cursor-pointer items-center justify-between px-4 py-1',
-                    ]"
-                  >
-                    <div class="flex items-center justify-start gap-2 pr-4">
-                      <UAvatar
-                        :src="`https://api.dicebear.com/6.x/shapes/svg?seed=${resource.id}`"
-                        size="sm"
-                      />
+                  New
+                </UBadge>
+              </div>
+            </TransitionFade>
+          </NuxtLink>
 
-                      <UTooltip
-                        v-if="resource.title.length > 19"
-                        :text="resource.title"
-                      >
-                        <span
-                          :class="[
-                            selected ? 'font-medium' : 'font-normal',
-                            'block max-w-40 truncate',
-                          ]"
-                        >
-                          {{ resource.title }}
-                        </span>
-                      </UTooltip>
-
-                      <span
-                        v-else
-                        :class="[
-                          selected ? 'font-medium' : 'font-normal',
-                          'block max-w-40 truncate',
-                        ]"
-                      >
-                        {{ resource.title }}
-                      </span>
-                    </div>
-
-                    <span
-                      v-if="selected"
-                      class="flex items-center text-amber-600"
-                    >
-                      <Icon name="ph:check-bold" class="h-5 w-5" />
-                    </span>
-                  </li>
-                </HeadlessListboxOption>
-              </HeadlessListboxOptions>
-            </transition>
-          </div>
-        </HeadlessListbox>
+          <UDropdownMenu
+            :items="resourceItems"
+            :ui="{
+              content: 'w-max',
+            }"
+          >
+            <UButton
+              icon="mingcute:down-fill"
+              color="neutral"
+              variant="ghost"
+            />
+          </UDropdownMenu>
+        </ContainerFlex>
       </div>
     </TransitionFade>
 

--- a/app/components/header/HeaderLeftBar.vue
+++ b/app/components/header/HeaderLeftBar.vue
@@ -341,6 +341,10 @@ const resourceItems = computed<DropdownMenuItem[][]>(() => [
 
         <UDropdownMenu
           :items="workspaceItems"
+          arrow
+          :content="{
+            align: 'start',
+          }"
           :ui="{
             content: 'w-max',
           }"
@@ -400,6 +404,10 @@ const resourceItems = computed<DropdownMenuItem[][]>(() => [
 
           <UDropdownMenu
             :items="collectionItems"
+            arrow
+            :content="{
+              align: 'center',
+            }"
             :ui="{
               content: 'w-max',
             }"
@@ -467,6 +475,10 @@ const resourceItems = computed<DropdownMenuItem[][]>(() => [
 
           <UDropdownMenu
             :items="resourceItems"
+            arrow
+            :content="{
+              align: 'end',
+            }"
             :ui="{
               content: 'w-max',
             }"

--- a/app/layouts/app-layout.vue
+++ b/app/layouts/app-layout.vue
@@ -47,8 +47,8 @@ const currentLayout = computed(() => {
 
     <USeparator />
 
-    <UMain>
+    <main>
       <slot />
-    </UMain>
+    </main>
   </div>
 </template>

--- a/app/layouts/dashboard-root.vue
+++ b/app/layouts/dashboard-root.vue
@@ -8,6 +8,10 @@
           <AppLogo class="h-6 w-auto" />
         </NuxtLink>
       </template>
+
+      <template #right>
+        <HeaderRightBar />
+      </template>
     </UHeader>
 
     <UMain>

--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -83,7 +83,7 @@ workspaceStore.setWorkspaces(workspaces.value || []);
               <div class="flex items-center gap-3">
                 <UAvatar
                   size="sm"
-                  :src="`https://api.dicebear.com/7.x/shapes/svg?seed=${personalWorkspace?.id}`"
+                  :src="`https://api.dicebear.com/9.x/shapes/svg?seed=${personalWorkspace?.id}`"
                   class="mt-1"
                 />
 
@@ -125,7 +125,7 @@ workspaceStore.setWorkspaces(workspaces.value || []);
                 <div class="flex w-full items-start justify-start gap-2">
                   <UAvatar
                     size="md"
-                    :src="`https://api.dicebear.com/7.x/shapes/svg?seed=${workspace.id}`"
+                    :src="`https://api.dicebear.com/9.x/shapes/svg?seed=${workspace.id}`"
                     class="mt-1"
                   />
 

--- a/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/index.vue
+++ b/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/index.vue
@@ -90,7 +90,11 @@ if (error.value) {
 
           <DataDisplay title="Image">
             <NuxtImg
-              :src="`${collection?.imageUrl}?t=${collection?.updated}`"
+              :src="
+                collection?.imageUrl.includes('dicebear')
+                  ? collection?.imageUrl
+                  : `${collection?.imageUrl}?t=${collection?.updated}`
+              "
               :alt="collection?.title"
               class="h-[200px] w-auto"
             />

--- a/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/resources/index.vue
+++ b/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/resources/index.vue
@@ -70,6 +70,8 @@ const sortedResources = computed(() => {
       return 0;
     });
   }
+
+  return resources;
 });
 
 const groupedResources = computed(() => {
@@ -147,7 +149,7 @@ const selectResourceType = (type: string) => {
 <template>
   <UContainer>
     <UPage>
-      <UPageHeader title="Resources"> </UPageHeader>
+      <UPageHeader title="Resources" />
 
       <UPageBody>
         <div>
@@ -182,6 +184,7 @@ const selectResourceType = (type: string) => {
                 icon="fa-solid:list"
                 @click="selectedView = 'list'"
               />
+
               <UButton
                 color="neutral"
                 :variant="selectedView === 'grouped' ? 'subtle' : 'outline'"

--- a/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/settings/index.vue
+++ b/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/settings/index.vue
@@ -301,7 +301,7 @@ const updateThumbnail = async (evt: any) => {
             <UAvatar
               :src="
                 collectionImage ||
-                'https://api.dicebear.com/6.x/shapes/svg?seed=collection'
+                'https://api.dicebear.com/9.x/shapes/svg/svg?seed=collection'
               "
               size="xl"
               alt="Collection Thumbnail"

--- a/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/settings/team.vue
+++ b/app/pages/dashboard/workspaces/[workspaceid]/collections/[collectionid]/settings/team.vue
@@ -431,7 +431,7 @@ const inviteMember = async () => {
       >
         <div class="flex items-center gap-3">
           <UAvatar
-            :src="`https://api.dicebear.com/7.x/shapes/svg?seed=${member.id}`"
+            :src="`https://api.dicebear.com/9.x/shapes/svg/svg?seed=${member.id}`"
             size="xl"
           />
 
@@ -518,7 +518,7 @@ const inviteMember = async () => {
       >
         <div class="flex items-center gap-3">
           <UAvatar
-            :src="`https://api.dicebear.com/7.x/shapes/svg?seed=${member.id}`"
+            :src="`https://api.dicebear.com/9.x/shapes/svg/svg?seed=${member.id}`"
             size="xl"
           />
 

--- a/app/pages/dashboard/workspaces/[workspaceid]/index.vue
+++ b/app/pages/dashboard/workspaces/[workspaceid]/index.vue
@@ -60,7 +60,10 @@ if (error.value) {
             </UButton>
           </div>
 
-          <div class="grid grid-cols-1 gap-5 lg:grid-cols-2 xl:grid-cols-3">
+          <div
+            v-if="workspace?.collections && workspace.collections.length > 0"
+            class="grid grid-cols-1 gap-5 lg:grid-cols-2 xl:grid-cols-3"
+          >
             <ULink
               v-for="collection in workspace?.collections"
               :key="collection.id"
@@ -92,6 +95,19 @@ if (error.value) {
                 </p>
               </div>
             </ULink>
+          </div>
+
+          <div
+            v-if="workspace?.collections?.length === 0"
+            class="flex flex-col items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-8"
+          >
+            <UIcon name="mingcute:empty-box-line" size="48" />
+
+            <p class="text-center text-lg font-medium">No collections found</p>
+
+            <p class="text-center text-sm text-slate-500">
+              You can add a new collection by clicking the button above.
+            </p>
           </div>
 
           <USeparator

--- a/app/pages/dashboard/workspaces/[workspaceid]/settings/team.vue
+++ b/app/pages/dashboard/workspaces/[workspaceid]/settings/team.vue
@@ -355,7 +355,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
   <div class="flex flex-col">
     <h2 class="text-xl">Team</h2>
 
-    <p class="pb-6 pt-1 text-slate-700">
+    <p class="pt-1 pb-6 text-slate-700">
       Invite your team members to collaborate on your workspace and projects.
     </p>
 
@@ -430,7 +430,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
       >
         <template #teamMembers>
           <div class="flex flex-col">
-            <div class="flex items-center justify-between gap-4 pb-4 pt-2">
+            <div class="flex items-center justify-between gap-4 pt-2 pb-4">
               <UInput
                 placeholder="Filter..."
                 icon="iconamoon:search-duotone"
@@ -448,7 +448,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
                 <UAvatar
                   size="xl"
                   class="rounded-sm"
-                  :src="`https://api.dicebear.com/7.x/shapes/svg?seed=${member.id}`"
+                  :src="`https://api.dicebear.com/9.x/shapes/svg?seed=${member.id}`"
                 />
 
                 <div class="flex flex-col">
@@ -516,7 +516,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
 
         <template #pendingInvitations>
           <div class="flex flex-col">
-            <div class="flex items-center justify-between gap-4 pb-4 pt-2">
+            <div class="flex items-center justify-between gap-4 pt-2 pb-4">
               <UInput
                 placeholder="Filter..."
                 icon="iconamoon:search-duotone"
@@ -534,7 +534,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
                 <UAvatar
                   size="xl"
                   class="rounded-sm"
-                  :src="`https://api.dicebear.com/7.x/shapes/svg?seed=${member.id}`"
+                  :src="`https://api.dicebear.com/9.x/shapes/svg?seed=${member.id}`"
                 />
 
                 <div class="flex flex-col">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,7 +24,6 @@ export default defineNuxtConfig({
   modules: [
     "@nuxt/ui",
     "nuxt-auth-utils",
-    "nuxt-headlessui",
     "dayjs-nuxt",
     "@pinia/nuxt",
     "@nuxt/image",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@codemirror/view": "^6.36.2",
     "@dagrejs/dagre": "^1.1.4",
-    "@headlessui/vue": "^1.7.23",
     "@nuxt/image": "^1.9.0",
     "@paralleldrive/cuid2": "^2.2.2",
     "@pinia/nuxt": "^0.11.3",
@@ -86,7 +85,6 @@
     "eslint-plugin-vue": "^10.5.0",
     "nuxt": "4.2.2",
     "nuxt-auth-utils": "0.5.26",
-    "nuxt-headlessui": "1.2.1",
     "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "prisma": "^6.16.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,7 +126,7 @@ model Collection {
 
     type String @default("other") // project | person | ... | other
 
-    imageUrl String  @default("https://api.dicebear.com/6.x/shapes/svg")
+    imageUrl String  @default("https://api.dicebear.com/9.x/shapes/svg")
     private  Boolean @default(false) // used to hide the collection from public view
 
     randomInt Int @default(0) // used to maintain order of collections   

--- a/server/api/auth/signup.ts
+++ b/server/api/auth/signup.ts
@@ -54,8 +54,8 @@ export default defineEventHandler(async (event) => {
   // Create a personal workspace for the user
   const workspace = await prisma.workspace.create({
     data: {
-      title: body.data.givenName + "'s Personal Workspace",
-      description: "Personal workspace for " + body.data.givenName,
+      title: "My Personal Workspace",
+      description: `Personal workspace for ${body.data.givenName} ${body.data.familyName}`,
       personal: true,
       type: "personal",
       WorkspaceMember: {

--- a/server/api/workspaces/[workspaceid]/collections/index.post.ts
+++ b/server/api/workspaces/[workspaceid]/collections/index.post.ts
@@ -50,7 +50,7 @@ export default defineEventHandler(async (event) => {
         },
       },
 
-      imageUrl: `https://api.dicebear.com/6.x/shapes/svg?seed=${nanoid()}`,
+      imageUrl: `https://api.dicebear.com/9.x/shapes/svg?seed=${nanoid()}`,
       type,
       workspaceId: workspaceid,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,13 +1270,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@headlessui/vue@^1.7.18", "@headlessui/vue@^1.7.23":
-  version "1.7.23"
-  resolved "https://registry.yarnpkg.com/@headlessui/vue/-/vue-1.7.23.tgz#7fe19dbeca35de9e6270c82c78c4864e6a6f7391"
-  integrity sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==
-  dependencies:
-    "@tanstack/vue-virtual" "^3.0.0-beta.60"
-
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -1907,7 +1900,7 @@
   optionalDependencies:
     ipx "^2.1.1"
 
-"@nuxt/kit@4.2.2", "@nuxt/kit@^4.0.1", "@nuxt/kit@^4.2.0", "@nuxt/kit@^4.2.1", "@nuxt/kit@^4.2.2":
+"@nuxt/kit@4.2.2", "@nuxt/kit@^4.2.0", "@nuxt/kit@^4.2.1", "@nuxt/kit@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-4.2.2.tgz#f3f900a59e8c8f71313e31366c9319806ac9c9e7"
   integrity sha512-ZAgYBrPz/yhVgDznBNdQj2vhmOp31haJbO0I0iah/P9atw+OHH7NJLUZ3PK+LOz/0fblKTN1XJVSi8YQ1TQ0KA==
@@ -3170,7 +3163,7 @@
   dependencies:
     "@tanstack/table-core" "8.21.3"
 
-"@tanstack/vue-virtual@^3.0.0-beta.60", "@tanstack/vue-virtual@^3.12.0", "@tanstack/vue-virtual@^3.13.13":
+"@tanstack/vue-virtual@^3.12.0", "@tanstack/vue-virtual@^3.13.13":
   version "3.13.13"
   resolved "https://registry.yarnpkg.com/@tanstack/vue-virtual/-/vue-virtual-3.13.13.tgz#8af64d1f832704ebf1217d119d224fecc0bb91af"
   integrity sha512-Cf2xIEE8nWAfsX0N5nihkPYMeQRT+pHt4NEkuP8rNCn6lVnLDiV8rC8IeIxbKmQC0yPnj4SIBLwXYVf86xxKTQ==
@@ -9785,15 +9778,6 @@ nuxt-auth-utils@0.5.26:
     pathe "^2.0.3"
     scule "^1.3.0"
     uncrypto "^0.1.3"
-
-nuxt-headlessui@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/nuxt-headlessui/-/nuxt-headlessui-1.2.1.tgz#19708da35c80daf993495cbb011324157c056787"
-  integrity sha512-0vwErENX7EQ0uV3+Al7nq6eOVIFSB7mEfio+iVvEyvliv5O+zE04zpNbn34Z/uSKhvXOwbOlNzn4JAyIdAT3Ow==
-  dependencies:
-    "@headlessui/vue" "^1.7.18"
-    "@nuxt/kit" "^4.0.1"
-    pathe "^2.0.3"
 
 nuxt@4.2.2:
   version "4.2.2"


### PR DESCRIPTION
## Summary by Sourcery

Replace legacy Headless UI-based listboxes with Nuxt UI dropdown menus in the header, update avatar and collection image URLs to DiceBear v9, and refine various dashboard layouts and workspace behaviors.

Bug Fixes:
- Ensure sorted resources computed property always returns a list to prevent undefined results.
- Avoid appending cache-busting query parameters to DiceBear-hosted collection images.
- Show a clear empty-state message when a workspace has no collections.

Enhancements:
- Refactor header navigation to use Nuxt UI dropdown menus for workspace, collection, and resource selection instead of custom Headless UI listboxes.
- Improve the profile dropdown with user avatar header item, additional navigation links, hidden-collections access, and aligned menu positioning.
- Adjust dashboard and workspace layouts, including replacing UMain with a semantic main tag, adding a right header slot, and refining spacing and empty states for collections.

Build:
- Remove nuxt-headlessui module and @headlessui/vue dependency from the project configuration and package.json.

Chores:
- Standardize DiceBear avatar and thumbnail URLs across the app to use the v9 API and update default personal workspace metadata on signup.